### PR TITLE
fix: add classes to allow V2 precision

### DIFF
--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -9,6 +9,7 @@ use InfluxDB\Driver\Exception as DriverException;
 use InfluxDB\Driver\Guzzle;
 use InfluxDB\Driver\QueryDriverInterface;
 use InfluxDB\Driver\UDP;
+use InfluxDB\Precision\InfluxDBPrecision;
 
 /**
  * Class Client
@@ -142,12 +143,14 @@ class Client
      * Use the given database
      *
      * @param  string $name
+     * @param InfluxDBPrecision $precision optional precision class
+     *
      * @return Database
      * @throws \InvalidArgumentException
      */
-    public function selectDB($name)
+    public function selectDB($name, InfluxDBPrecision $precision = NULL)
     {
-        return new Database($name, $this);
+        return $precision === null ? new Database($name, $this) : new Database($name, $this, $precision);
     }
 
     /**

--- a/src/InfluxDB/Precision/InfluxDBPrecision.php
+++ b/src/InfluxDB/Precision/InfluxDBPrecision.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace InfluxDB\Precision;
+
+class InfluxDBPrecision
+{
+    /**
+     * Precision constants
+     */
+    public const PRECISION_MILLISECONDS = 'ms';
+    public const PRECISION_SECONDS = 's';
+    public const PRECISION_MINUTES = 'm';
+    public const PRECISION_HOURS = 'h';
+}

--- a/src/InfluxDB/Precision/InfluxDBV1Precision.php
+++ b/src/InfluxDB/Precision/InfluxDBV1Precision.php
@@ -1,0 +1,11 @@
+<?php
+namespace InfluxDB\Precision;
+
+class InfluxDBV1Precision extends InfluxDBPrecision
+{
+    /**
+     * Precision constants
+     */
+    public const PRECISION_NANOSECONDS = 'n';
+    public const PRECISION_MICROSECONDS = 'u';
+}

--- a/src/InfluxDB/Precision/InfluxDBV2Precision.php
+++ b/src/InfluxDB/Precision/InfluxDBV2Precision.php
@@ -1,0 +1,11 @@
+<?php
+namespace InfluxDB\Precision;
+
+class InfluxDBV2Precision extends InfluxDBPrecision
+{
+    /**
+     * Precision constants
+     */
+    public const PRECISION_NANOSECONDS = 'ns';
+    public const PRECISION_MICROSECONDS = 'us';
+}


### PR DESCRIPTION
Should allow this library to be used with InfluxDB v2 in v1 mode.